### PR TITLE
fix: surface llm provider errors

### DIFF
--- a/server/modules/llm/ollama/engine.js
+++ b/server/modules/llm/ollama/engine.js
@@ -37,6 +37,11 @@ module.exports = {
         res.on('end', () => {
           try {
             const json = JSON.parse(data)
+            if (res.statusCode < 200 || res.statusCode >= 300 || json.error) {
+              const errMsg = json.error || `Ollama request failed with status ${res.statusCode}`
+              reject(new Error(errMsg))
+              return
+            }
             resolve(_.get(json, 'response', ''))
           } catch (err) {
             reject(err)

--- a/server/modules/llm/openai/engine.js
+++ b/server/modules/llm/openai/engine.js
@@ -43,6 +43,11 @@ module.exports = {
         res.on('end', () => {
           try {
             const json = JSON.parse(data)
+            if (res.statusCode < 200 || res.statusCode >= 300 || json.error) {
+              const errMsg = _.get(json, 'error.message', `OpenAI request failed with status ${res.statusCode}`)
+              reject(new Error(errMsg))
+              return
+            }
             resolve(_.get(json, 'choices[0].message.content', ''))
           } catch (err) {
             reject(err)


### PR DESCRIPTION
## Summary
- reject OpenAI requests when status is not 2xx or API returns an error payload
- reject Ollama requests on HTTP errors or error responses to avoid blank completions

## Testing
- `npm test` *(fails: 'WIKI' is not defined (no-undef) at server/modules/rendering/html-image-prefetch/renderer.js:14:5)*

------
https://chatgpt.com/codex/tasks/task_e_68bf50724fe4832b9e2fa2a5b7ddb71a