### PR TITLE
feat: add chat GraphQL API

### DIFF
--- a/server/graph/index.js
+++ b/server/graph/index.js
@@ -24,6 +24,10 @@ let schemas = fs.readdirSync(path.join(WIKI.SERVERPATH, 'graph/schemas'))
 schemas.forEach(schema => {
   typeDefs.push(fs.readFileSync(path.join(WIKI.SERVERPATH, `graph/schemas/${schema}`), 'utf8'))
 })
+// Ensure chat schema is registered
+if (!schemas.includes('chat.graphql')) {
+  typeDefs.push(fs.readFileSync(path.join(WIKI.SERVERPATH, 'graph/schemas/chat.graphql'), 'utf8'))
+}
 
 // Resolvers
 
@@ -34,6 +38,10 @@ const resolversObj = _.values(autoload(path.join(WIKI.SERVERPATH, 'graph/resolve
 resolversObj.forEach(resolver => {
   _.merge(resolvers, resolver)
 })
+// Register chat resolver explicitly
+if (fs.existsSync(path.join(__dirname, 'resolvers/chat.js'))) {
+  _.merge(resolvers, require('./resolvers/chat'))
+}
 
 // Directives
 

--- a/server/graph/resolvers/chat.js
+++ b/server/graph/resolvers/chat.js
@@ -1,0 +1,23 @@
+/* global WIKI */
+
+module.exports = {
+  Query: {
+    async chatAsk(obj, args, context) {
+      if (!context.req.user || !WIKI.auth.checkAccess(context.req.user, ['read:pages'])) {
+        throw new Error('Forbidden')
+      }
+      const answer = await WIKI.llm.generate(args.question)
+      return { answer }
+    }
+  },
+  Mutation: {
+    async chatAsk(obj, args, context) {
+      if (!context.req.user || !WIKI.auth.checkAccess(context.req.user, ['read:pages'])) {
+        throw new Error('Forbidden')
+      }
+      const answer = await WIKI.llm.generate(args.question)
+      return { answer }
+    }
+  }
+}
+

--- a/server/graph/schemas/chat.graphql
+++ b/server/graph/schemas/chat.graphql
@@ -1,0 +1,24 @@
+# ===============================================
+# CHAT
+# ===============================================
+
+extend type Query {
+  chatAsk(
+    question: String!
+  ): ChatResponse! @auth(requires: ["read:pages"])
+}
+
+extend type Mutation {
+  chatAsk(
+    question: String!
+  ): ChatResponse! @auth(requires: ["read:pages"])
+}
+
+# -----------------------------------------------
+# TYPES
+# -----------------------------------------------
+
+type ChatResponse {
+  answer: String!
+}
+


### PR DESCRIPTION
## Summary
- add chatAsk query and mutation schema
- implement chatAsk resolver with permission checks and LLM delegation
- register chat schema and resolver

## Testing
- `npm test` *(fails: 'WIKI' is not defined and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3edca180832b8e152646df455dbc