### PR TITLE
Search wiki pages for chat context

### DIFF
--- a/server/graph/resolvers/chat.js
+++ b/server/graph/resolvers/chat.js
@@ -3,21 +3,49 @@
 module.exports = {
   Query: {
     async chatAsk(obj, args, context) {
-      if (!context.req.user || !WIKI.auth.checkAccess(context.req.user, ['read:pages'])) {
-        throw new Error('Forbidden')
-      }
-      const answer = await WIKI.llm.generate(args.question)
-      return { answer }
+      return chatAskResolver(obj, args, context)
     }
   },
   Mutation: {
     async chatAsk(obj, args, context) {
-      if (!context.req.user || !WIKI.auth.checkAccess(context.req.user, ['read:pages'])) {
-        throw new Error('Forbidden')
-      }
-      const answer = await WIKI.llm.generate(args.question)
-      return { answer }
+      return chatAskResolver(obj, args, context)
     }
   }
+}
+
+async function chatAskResolver(obj, args, context) {
+  if (!context.req.user || !WIKI.auth.checkAccess(context.req.user, ['read:pages'])) {
+    throw new Error('Forbidden')
+  }
+
+  let contextDocs = []
+  if (WIKI.data.searchEngine) {
+    try {
+      const resp = await WIKI.data.searchEngine.query(args.question, {})
+      const permitted = resp.results.filter(r => {
+        return WIKI.auth.checkAccess(context.req.user, ['read:pages'], {
+          path: r.path,
+          locale: r.locale,
+          tags: r.tags
+        })
+      })
+
+      for (const res of permitted.slice(0, 5)) {
+        try {
+          const page = await WIKI.models.pages.getPage({ path: res.path, locale: res.locale })
+          if (page && page.render) {
+            contextDocs.push(WIKI.models.pages.cleanHTML(page.render))
+          }
+        } catch (err) {
+          WIKI.logger.warn('(CHAT) Failed to fetch page for context', err)
+        }
+      }
+    } catch (err) {
+      WIKI.logger.warn('(CHAT) Search failed', err)
+    }
+  }
+
+  const answer = await WIKI.llm.generate(args.question, contextDocs)
+  return { answer }
 }
 


### PR DESCRIPTION
## Summary
- search wiki pages for relevant content before sending chat questions to the LLM
- filter search results through existing permission checks
- feed cleaned page content as context for LLM responses

## Testing
- `yarn test` *(fails: 'WIKI' is not defined in server/modules/rendering/html-image-prefetch/renderer.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3ede0eac832bb5e19368b112ce0b