### PR TITLE
Add AI chat component

### DIFF
--- a/client/components/ai-chat.vue
+++ b/client/components/ai-chat.vue
@@ -1,0 +1,71 @@
+<template lang='pug'>
+  v-dialog(v-model='model', max-width='600')
+    v-card
+      v-card-title AI Chat
+      v-card-text
+        .messages
+          div(v-for='(msg, idx) in messages', :key='idx', class='mb-2')
+            div.font-weight-bold {{ msg.role === 'user' ? 'You' : 'AI' }}
+            div {{ msg.content }}
+      v-divider
+      v-card-actions
+        v-text-field(
+          v-model='question'
+          placeholder='Ask a question'
+          hide-details
+          clearable
+          @keyup.enter='ask'
+        )
+        v-btn(color='primary', @click='ask', :disabled='!question') Send
+</template>
+
+<script>
+import chatAsk from '../graph/chat/chat-query-ask.gql'
+
+export default {
+  name: 'AiChat',
+  props: {
+    value: Boolean
+  },
+  data () {
+    return {
+      question: '',
+      messages: []
+    }
+  },
+  computed: {
+    model: {
+      get () {
+        return this.value
+      },
+      set (val) {
+        this.$emit('input', val)
+      }
+    }
+  },
+  methods: {
+    async ask () {
+      const question = this.question.trim()
+      if (!question) { return }
+      this.messages.push({ role: 'user', content: question })
+      this.question = ''
+      try {
+        const resp = await this.$apollo.query({
+          query: chatAsk,
+          variables: { question }
+        })
+        this.messages.push({ role: 'ai', content: resp.data.chatAsk.answer })
+      } catch (err) {
+        this.$store.commit('pushGraphError', err)
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.messages {
+  max-height: 300px;
+  overflow-y: auto;
+}
+</style>

--- a/client/components/common/nav-header.vue
+++ b/client/components/common/nav-header.vue
@@ -83,6 +83,12 @@
 
           slot(name='actions')
 
+          v-tooltip(bottom)
+            template(v-slot:activator='{ on }')
+              v-btn.ml-2(icon, v-on='on', @click='aiChat = true', aria-label='AI Chat')
+                v-icon(color='grey') mdi-robot
+            span AI Chat
+
           //- (mobile) SEARCH TOGGLE
 
           v-btn(
@@ -241,6 +247,7 @@
     page-selector(mode='create', v-model='duplicateOpts.modal', :open-handler='pageDuplicateHandle', :path='duplicateOpts.path', :locale='duplicateOpts.locale')
     page-delete(v-model='deletePageModal', v-if='path && path.length')
     page-convert(v-model='convertPageModal', v-if='path && path.length')
+    ai-chat(v-model='aiChat')
 
     .nav-header-dev(v-if='isDevMode')
       v-icon mdi-alert
@@ -260,7 +267,8 @@ import movePageMutation from 'gql/common/common-pages-mutation-move.gql'
 export default {
   components: {
     PageDelete: () => import('./page-delete.vue'),
-    PageConvert: () => import('./page-convert.vue')
+    PageConvert: () => import('./page-convert.vue'),
+    AiChat: () => import('../ai-chat.vue')
   },
   props: {
     dense: {
@@ -281,6 +289,7 @@ export default {
       movePageModal: false,
       convertPageModal: false,
       deletePageModal: false,
+      aiChat: false,
       locales: siteLangs,
       isDevMode: false,
       duplicateOpts: {

--- a/client/graph/chat/chat-mutation-ask.gql
+++ b/client/graph/chat/chat-mutation-ask.gql
@@ -1,0 +1,5 @@
+mutation ($question: String!) {
+  chatAsk(question: $question) {
+    answer
+  }
+}

--- a/client/graph/chat/chat-query-ask.gql
+++ b/client/graph/chat/chat-query-ask.gql
@@ -1,0 +1,5 @@
+query ($question: String!) {
+  chatAsk(question: $question) {
+    answer
+  }
+}


### PR DESCRIPTION
## Summary
- add GraphQL queries for chatAsk
- create ai-chat component with conversation display and input
- expose chat via header with trigger button

## Testing
- `yarn test` *(fails: 'WIKI' is not defined and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3ede41f8832bb17f781bc95f2d3d