### PR TITLE
Support page drafts in chat responses

### DIFF
--- a/client/components/chat.vue
+++ b/client/components/chat.vue
@@ -1,0 +1,46 @@
+<template lang="pug">
+  v-container
+    v-text-field(v-model='question', label='Ask a question')
+    v-btn.mt-2(color='primary', @click='ask') Ask
+    div(v-if='answer')
+      .mt-4 {{ answer }}
+    div(v-if='draft')
+      v-divider.my-4
+      h3 {{ draft.title }}
+      pre {{ draft.content }}
+      v-btn.mt-2(color='green', @click='createPage') Create Page from Draft
+</template>
+
+<script>
+import chatAsk from 'gql/chat/chat-ask.gql'
+import { Base64 } from 'js-base64'
+
+export default {
+  data() {
+    return {
+      question: '',
+      answer: '',
+      draft: null
+    }
+  },
+  methods: {
+    async ask() {
+      const resp = await this.$apollo.query({
+        query: chatAsk,
+        variables: { question: this.question, draft: true },
+        fetchPolicy: 'no-cache'
+      })
+      this.answer = resp.data.chatAsk.answer
+      this.draft = resp.data.chatAsk.pageDraft
+    },
+    createPage() {
+      if (!this.draft) return
+      const slug = this.draft.title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
+      const content = Base64.encode(this.draft.content)
+      const title = encodeURIComponent(this.draft.title)
+      const url = `/e/en/${slug}?draftTitle=${title}&draftContent=${encodeURIComponent(content)}`
+      window.location.assign(url)
+    }
+  }
+}
+</script>

--- a/client/components/editor.vue
+++ b/client/components/editor.vue
@@ -238,8 +238,18 @@ export default {
   mounted() {
     this.$store.set('editor/mode', this.initMode || 'create')
 
+    const params = new URLSearchParams(window.location.search)
+    const draftTitle = params.get('draftTitle')
+    const draftContent = params.get('draftContent')
+
     this.initContentParsed = this.initContent ? Base64.decode(this.initContent) : ''
+    if (draftContent) {
+      this.initContentParsed = Base64.decode(draftContent)
+    }
     this.$store.set('editor/content', this.initContentParsed)
+    if (draftTitle) {
+      this.$store.set('page/title', draftTitle)
+    }
     if (this.mode === 'create' && !this.initEditor) {
       _.delay(() => {
         this.dialogEditorSelector = true

--- a/client/graph/chat/chat-ask.gql
+++ b/client/graph/chat/chat-ask.gql
@@ -1,0 +1,9 @@
+query ($question: String!, $draft: Boolean) {
+  chatAsk(question: $question, draft: $draft) {
+    answer
+    pageDraft {
+      title
+      content
+    }
+  }
+}

--- a/server/graph/resolvers/chat.js
+++ b/server/graph/resolvers/chat.js
@@ -6,8 +6,23 @@ module.exports = {
       if (!context.req.user || !WIKI.auth.checkAccess(context.req.user, ['read:pages'])) {
         throw new Error('Forbidden')
       }
-      const answer = await WIKI.llm.generate(args.question)
-      return { answer }
+      const raw = await WIKI.llm.generate(args.question, [], { draft: args.draft })
+      let response = { answer: raw }
+      if (args.draft) {
+        try {
+          const data = JSON.parse(raw)
+          response = {
+            answer: data.answer || '',
+            pageDraft: {
+              title: data.title || '',
+              content: data.content || ''
+            }
+          }
+        } catch (err) {
+          response = { answer: raw }
+        }
+      }
+      return response
     }
   },
   Mutation: {
@@ -15,8 +30,23 @@ module.exports = {
       if (!context.req.user || !WIKI.auth.checkAccess(context.req.user, ['read:pages'])) {
         throw new Error('Forbidden')
       }
-      const answer = await WIKI.llm.generate(args.question)
-      return { answer }
+      const raw = await WIKI.llm.generate(args.question, [], { draft: args.draft })
+      let response = { answer: raw }
+      if (args.draft) {
+        try {
+          const data = JSON.parse(raw)
+          response = {
+            answer: data.answer || '',
+            pageDraft: {
+              title: data.title || '',
+              content: data.content || ''
+            }
+          }
+        } catch (err) {
+          response = { answer: raw }
+        }
+      }
+      return response
     }
   }
 }

--- a/server/graph/schemas/chat.graphql
+++ b/server/graph/schemas/chat.graphql
@@ -5,12 +5,14 @@
 extend type Query {
   chatAsk(
     question: String!
+    draft: Boolean
   ): ChatResponse! @auth(requires: ["read:pages"])
 }
 
 extend type Mutation {
   chatAsk(
     question: String!
+    draft: Boolean
   ): ChatResponse! @auth(requires: ["read:pages"])
 }
 
@@ -20,5 +22,11 @@ extend type Mutation {
 
 type ChatResponse {
   answer: String!
+  pageDraft: ChatPageDraft
+}
+
+type ChatPageDraft {
+  title: String!
+  content: String!
 }
 


### PR DESCRIPTION
## Summary
- extend chat GraphQL schema to request draft output
- parse LLM JSON to return title and content drafts
- add client chat component with button to create page from draft
- allow editor to prefill title and content from query parameters

## Testing
- `yarn test` *(fails: 'WIKI' is not defined at server/modules/rendering/html-image-prefetch/renderer.js:14)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3ede8304832bb4192a6d11dfe6a6