### PR TITLE
Add page draft support to chat

### DIFF
--- a/client/components/ai-chat.vue
+++ b/client/components/ai-chat.vue
@@ -61,7 +61,7 @@ export default {
       } catch (err) {
         this.$store.commit('pushGraphError', err)
       }
-    }
+    },
     createPage(draft) {
       const locale = this.$store.get('page/locale') || 'en'
       const path = uslug(draft.title)

--- a/client/components/editor.vue
+++ b/client/components/editor.vue
@@ -240,6 +240,21 @@ export default {
 
     this.initContentParsed = this.initContent ? Base64.decode(this.initContent) : ''
     this.$store.set('editor/content', this.initContentParsed)
+    const params = new URLSearchParams(window.location.search)
+    const draftTitle = params.get('title')
+    const draftContent = params.get('content')
+    if (draftTitle) {
+      this.$store.set('page/title', draftTitle)
+    }
+    if (draftContent) {
+      try {
+        const decoded = Base64.decode(draftContent)
+        this.$store.set('editor/content', decoded)
+        this.initContentParsed = decoded
+      } catch (err) {
+        // ignore decode errors
+      }
+    }
     if (this.mode === 'create' && !this.initEditor) {
       _.delay(() => {
         this.dialogEditorSelector = true

--- a/client/graph/chat/chat-mutation-ask.gql
+++ b/client/graph/chat/chat-mutation-ask.gql
@@ -1,5 +1,9 @@
-mutation ($question: String!) {
-  chatAsk(question: $question) {
+mutation ($question: String!, $pageDraft: Boolean) {
+  chatAsk(question: $question, pageDraft: $pageDraft) {
     answer
+    draft {
+      title
+      content
+    }
   }
 }

--- a/client/graph/chat/chat-query-ask.gql
+++ b/client/graph/chat/chat-query-ask.gql
@@ -1,5 +1,9 @@
-query ($question: String!) {
-  chatAsk(question: $question) {
+query ($question: String!, $pageDraft: Boolean) {
+  chatAsk(question: $question, pageDraft: $pageDraft) {
     answer
+    draft {
+      title
+      content
+    }
   }
 }

--- a/server/graph/resolvers/chat.js
+++ b/server/graph/resolvers/chat.js
@@ -1,4 +1,5 @@
 /* global WIKI */
+const _ = require('lodash')
 
 module.exports = {
   Query: {
@@ -45,7 +46,13 @@ async function chatAskResolver(obj, args, context) {
     }
   }
 
-  const answer = await WIKI.llm.generate(args.question, contextDocs)
-  return { answer }
+  const llmResp = await WIKI.llm.generate(args.question, contextDocs, { pageDraft: args.pageDraft })
+  if (_.isString(llmResp)) {
+    return { answer: llmResp }
+  }
+  return {
+    answer: _.get(llmResp, 'answer', ''),
+    draft: _.get(llmResp, 'draft', null)
+  }
 }
 

--- a/server/graph/schemas/chat.graphql
+++ b/server/graph/schemas/chat.graphql
@@ -4,13 +4,15 @@
 
 extend type Query {
   chatAsk(
-    question: String!
+    question: String!,
+    pageDraft: Boolean
   ): ChatResponse! @auth(requires: ["read:pages"])
 }
 
 extend type Mutation {
   chatAsk(
-    question: String!
+    question: String!,
+    pageDraft: Boolean
   ): ChatResponse! @auth(requires: ["read:pages"])
 }
 
@@ -20,5 +22,10 @@ extend type Mutation {
 
 type ChatResponse {
   answer: String!
+  draft: ChatPageDraft
 }
 
+type ChatPageDraft {
+  title: String!
+  content: String!
+}


### PR DESCRIPTION
## Summary
- allow chat queries to request optional page drafts
- show AI draft responses with a button to open the editor prefilled with the draft
- prefill editor content from URL parameters

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5cb5aeac832ba1f8e7ee928876c3