### PR TITLE
Add page draft support to chat

### DIFF
--- a/client/components/ai-chat.vue
+++ b/client/components/ai-chat.vue
@@ -61,7 +61,7 @@ export default {
       } catch (err) {
         this.$store.commit('pushGraphError', err)
       }
-    }
+    },
     createPage(draft) {
       const locale = this.$store.get('page/locale') || 'en'
       const path = uslug(draft.title)


### PR DESCRIPTION
## Summary
- add missing comma between methods in AI chat component

## Testing
- `yarn test` *(fails: 'WIKI' is not defined at server/modules/rendering/html-image-prefetch/renderer.js:14:5)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5e9e6524832b85238e3a91cc90c5