### PR TITLE
Restrict chat to signed users

### DIFF
--- a/server/graph/resolvers/chat.js
+++ b/server/graph/resolvers/chat.js
@@ -15,7 +15,7 @@ module.exports = {
 }
 
 async function chatAskResolver(obj, args, context) {
-  if (!context.req.user || !WIKI.auth.checkAccess(context.req.user, ['read:pages'])) {
+  if (!context.req.user || context.req.user.id === 2) {
     throw new Error('Forbidden')
   }
 

--- a/server/graph/resolvers/chat.js
+++ b/server/graph/resolvers/chat.js
@@ -15,7 +15,11 @@ module.exports = {
 }
 
 async function chatAskResolver(obj, args, context) {
-  if (!context.req.user || context.req.user.id === 2) {
+  if (
+    !context.req.user ||
+    context.req.user.id === 2 ||
+    !WIKI.auth.checkAccess(context.req.user, ['read:pages'])
+  ) {
     throw new Error('Forbidden')
   }
 


### PR DESCRIPTION
## Summary
- block guest account from Chat GraphQL resolver

## Testing
- `yarn test` *(fails: `WIKI` is not defined and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c043cfa000832b9b9b23cb28b94004