### PR TITLE
Add read permission guard to chat resolver

### DIFF
--- a/server/graph/resolvers/chat.js
+++ b/server/graph/resolvers/chat.js
@@ -15,7 +15,11 @@ module.exports = {
 }
 
 async function chatAskResolver(obj, args, context) {
-  if (!context.req.user || context.req.user.id === 2) {
+  if (
+    !context.req.user ||
+    context.req.user.id === 2 ||
+    !WIKI.auth.checkAccess(context.req.user, ['read:pages'])
+  ) {
     throw new Error('Forbidden')
   }
 


### PR DESCRIPTION
## Summary
- require `read:pages` permission in chat GraphQL resolver and still reject guest account

## Testing
- `yarn test` *(fails: 'WIKI' is not defined and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c04779221c832ba44ba44bd9c0e115