### PR TITLE
Require vector store configuration in LLM settings

### DIFF
--- a/client/components/admin/admin-llm.vue
+++ b/client/components/admin/admin-llm.vue
@@ -44,6 +44,13 @@
             .admin-providerlogo
               img(:src='provider.logo', :alt='provider.title')
           v-card-text
+            v-text-field(
+              outlined,
+              :label="$t('admin:llm.vectorStore')",
+              v-model='vectorStore',
+              prepend-icon='mdi-database',
+              required
+            )
             .overline.mb-5 {{$t('admin:llm.providerConfig')}}
             .body-2.ml-3(v-if='!provider.config || provider.config.length < 1'): em {{$t('admin:llm.providerNoConfig')}}
             template(v-else, v-for='cfg in provider.config')
@@ -106,7 +113,8 @@ export default {
   data () {
     return {
       providers: [],
-      selectedProvider: ''
+      selectedProvider: '',
+      vectorStore: ''
     }
   },
   computed: {
@@ -125,7 +133,8 @@ export default {
             provider: {
               key: this.selectedProvider,
               config: this.provider.config.map(cfg => ({ ...cfg, value: JSON.stringify({ v: cfg.value.value }) }))
-            }
+            },
+            vectorStore: this.vectorStore
           }
         })
         if (_.get(resp, 'data.llm.updateProvider.responseResult.succeeded', false)) {
@@ -147,10 +156,13 @@ export default {
     providers: {
       query: providersQuery,
       fetchPolicy: 'network-only',
-      update: (data) => _.cloneDeep(data.llm.providers).map(prov => ({
-        ...prov,
-        config: _.sortBy(prov.config.map(cfg => ({ ...cfg, value: JSON.parse(cfg.value) })), [t => t.value.order])
-      })),
+      update (data) {
+        this.vectorStore = _.get(data, 'llm.vectorStore', '')
+        return _.cloneDeep(data.llm.providers).map(prov => ({
+          ...prov,
+          config: _.sortBy(prov.config.map(cfg => ({ ...cfg, value: JSON.parse(cfg.value) })), [t => t.value.order])
+        }))
+      },
       watchLoading (isLoading) {
         this.$store.commit(`loading${isLoading ? 'Start' : 'Stop'}`, 'admin-llm-refresh')
       }

--- a/client/graph/admin/llm/llm-mutation-save-provider.gql
+++ b/client/graph/admin/llm/llm-mutation-save-provider.gql
@@ -1,6 +1,6 @@
-mutation($provider: LLMProviderInput!) {
+mutation($provider: LLMProviderInput!, $vectorStore: String!) {
   llm {
-    updateProvider(provider: $provider) {
+    updateProvider(provider: $provider, vectorStore: $vectorStore) {
       responseResult {
         succeeded
         slug

--- a/client/graph/admin/llm/llm-query-providers.gql
+++ b/client/graph/admin/llm/llm-query-providers.gql
@@ -13,6 +13,7 @@ query {
         value
       }
     }
+    vectorStore
   }
 }
 

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -109,6 +109,14 @@ bindIP: 0.0.0.0
 llm:
   # Provider to use, possible values: openai, ollama
   provider: openai
+  # Vector store provider: pgvector, neo4j
+  vectorStore: neo4j
+
+  # ++++++ For neo4j only ++++++
+  neo4j:
+    url: bolt://localhost:7687
+    username: neo4j
+    password: changeme
 
   # ++++++ For openai only ++++++
   openai:

--- a/server/core/kernel.js
+++ b/server/core/kernel.js
@@ -84,9 +84,16 @@ module.exports = {
     await WIKI.models.commentProviders.initProvider()
     await WIKI.models.searchEngines.initEngine()
     await WIKI.models.storage.initTargets()
-    WIKI.memory = require('../modules/memory/vector')
-    if (_.isFunction(WIKI.memory.init)) {
+    const vectorStore = _.get(WIKI.config, 'llm.vectorStore', '')
+    if (vectorStore === 'neo4j') {
+      WIKI.memory = require('../modules/memory/neo4j')
+    } else if (vectorStore === 'pgvector') {
+      WIKI.memory = require('../modules/memory/vector')
+    }
+    if (WIKI.memory && _.isFunction(WIKI.memory.init)) {
       await WIKI.memory.init()
+    } else {
+      WIKI.memory = null
     }
     WIKI.scheduler.start()
 

--- a/server/graph/resolvers/chat.js
+++ b/server/graph/resolvers/chat.js
@@ -20,7 +20,7 @@ async function chatAskResolver(obj, args, context) {
   }
 
   let contextDocs = []
-  if (WIKI.memory && _.isFunction(WIKI.llm.embed)) {
+  if (WIKI.memory && _.isFunction(WIKI.llm.embed) && _.get(WIKI.config, 'llm.vectorStore')) {
     try {
       const qEmbedding = await WIKI.llm.embed(args.question)
       const memories = await WIKI.memory.search(qEmbedding, { limit: 5 })

--- a/server/graph/resolvers/llm.js
+++ b/server/graph/resolvers/llm.js
@@ -57,6 +57,17 @@ module.exports = {
         _.set(WIKI.config, 'llm.vectorStore', args.vectorStore)
         await WIKI.configSvc.saveToDb(['llm'])
         if (WIKI.llm) { WIKI.llm.init() }
+        const store = _.get(WIKI.config, 'llm.vectorStore', '')
+        if (store === 'neo4j') {
+          delete require.cache[require.resolve('../../modules/memory/neo4j')]
+          WIKI.memory = require('../../modules/memory/neo4j')
+        } else if (store === 'pgvector') {
+          delete require.cache[require.resolve('../../modules/memory/vector')]
+          WIKI.memory = require('../../modules/memory/vector')
+        } else {
+          WIKI.memory = null
+        }
+        if (WIKI.memory && _.isFunction(WIKI.memory.init)) { WIKI.memory.init() }
         return {
           responseResult: graphHelper.generateSuccess('LLM configuration updated successfully')
         }

--- a/server/graph/resolvers/llm.js
+++ b/server/graph/resolvers/llm.js
@@ -40,6 +40,9 @@ module.exports = {
       }
       if (args.orderBy) { providers = _.sortBy(providers, [args.orderBy]) }
       return providers
+    },
+    async vectorStore () {
+      return _.get(WIKI.config, 'llm.vectorStore', '')
     }
   },
   LLMMutation: {
@@ -51,6 +54,7 @@ module.exports = {
         }, {})
         _.set(WIKI.config, 'llm.provider', args.provider.key)
         _.set(WIKI.config, ['llm', args.provider.key], cfg)
+        _.set(WIKI.config, 'llm.vectorStore', args.vectorStore)
         await WIKI.configSvc.saveToDb(['llm'])
         if (WIKI.llm) { WIKI.llm.init() }
         return {

--- a/server/graph/schemas/llm.graphql
+++ b/server/graph/schemas/llm.graphql
@@ -16,6 +16,7 @@ extend type Mutation {
 
 type LLMQuery {
   providers(orderBy: String): [LLMProvider] @auth(requires: ["manage:system"])
+  vectorStore: String @auth(requires: ["manage:system"])
 }
 
 # -----------------------------------------------
@@ -23,7 +24,7 @@ type LLMQuery {
 # -----------------------------------------------
 
 type LLMMutation {
-  updateProvider(provider: LLMProviderInput!): DefaultResponse @auth(requires: ["manage:system"])
+  updateProvider(provider: LLMProviderInput!, vectorStore: String!): DefaultResponse @auth(requires: ["manage:system"])
 }
 
 # -----------------------------------------------

--- a/server/locales/en.yml
+++ b/server/locales/en.yml
@@ -5,4 +5,5 @@ admin:
     providers: Providers
     providerConfig: Provider Configuration
     providerNoConfig: No configuration required for this provider.
+    vectorStore: Vector Store Connection
     configSaveSuccess: LLM configuration saved successfully

--- a/server/modules/memory/neo4j.js
+++ b/server/modules/memory/neo4j.js
@@ -1,0 +1,54 @@
+/* global WIKI */
+const _ = require('lodash')
+let driver = null
+
+module.exports = {
+  async init () {
+    let neo4j
+    try {
+      neo4j = require('neo4j-driver')
+    } catch (err) {
+      WIKI.logger.warn('(MEMORY) Neo4j driver not available')
+      return
+    }
+    const url = _.get(WIKI.config, 'llm.neo4j.url', '')
+    const username = _.get(WIKI.config, 'llm.neo4j.username', '')
+    const password = _.get(WIKI.config, 'llm.neo4j.password', '')
+    if (!url) {
+      WIKI.logger.info('(MEMORY) Neo4j vector store disabled: missing connection URL')
+      return
+    }
+    driver = neo4j.driver(url, neo4j.auth.basic(username, password))
+  },
+  async store ({ pageId, memoryPageId, embedding }) {
+    if (!driver || !embedding || embedding.length === 0) { return }
+    const session = driver.session()
+    try {
+      await session.run(
+        'MERGE (p:Page {id: $pageId}) SET p.embedding = $embedding, p.memoryPageId = $memoryPageId',
+        { pageId, memoryPageId, embedding }
+      )
+    } catch (err) {
+      WIKI.logger.warn('(MEMORY) Failed to store embedding', err)
+    } finally {
+      await session.close()
+    }
+  },
+  async search (embedding, opts = {}) {
+    if (!driver || !embedding || embedding.length === 0) { return [] }
+    const session = driver.session()
+    const limit = _.get(opts, 'limit', 5)
+    try {
+      const res = await session.run(
+        'MATCH (p:Page) WHERE p.embedding IS NOT NULL WITH p, gds.similarity.cosine(p.embedding, $embedding) AS score RETURN p.id AS pageId, p.memoryPageId AS memoryPageId ORDER BY score DESC LIMIT $limit',
+        { embedding, limit }
+      )
+      return res.records.map(r => ({ pageId: r.get('pageId'), memoryPageId: r.get('memoryPageId') }))
+    } catch (err) {
+      WIKI.logger.warn('(MEMORY) Search failed', err)
+      return []
+    } finally {
+      await session.close()
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add vector store field to LLM admin page and GraphQL API
- guard chat resolver by configured vector store
- introduce placeholder Neo4j memory module

## Testing
- `yarn test` *(fails: 'WIKI' is not defined in renderer.js)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c049dbfa84832b9b34f5f43b777c86