### PR TITLE
Require vector store configuration in LLM settings

### DIFF
--- a/server/graph/resolvers/llm.js
+++ b/server/graph/resolvers/llm.js
@@ -57,6 +57,17 @@ module.exports = {
         _.set(WIKI.config, 'llm.vectorStore', args.vectorStore)
         await WIKI.configSvc.saveToDb(['llm'])
         if (WIKI.llm) { WIKI.llm.init() }
+        const store = _.get(WIKI.config, 'llm.vectorStore', '')
+        if (store === 'neo4j') {
+          delete require.cache[require.resolve('../../modules/memory/neo4j')]
+          WIKI.memory = require('../../modules/memory/neo4j')
+        } else if (store === 'pgvector') {
+          delete require.cache[require.resolve('../../modules/memory/vector')]
+          WIKI.memory = require('../../modules/memory/vector')
+        } else {
+          WIKI.memory = null
+        }
+        if (WIKI.memory && _.isFunction(WIKI.memory.init)) { WIKI.memory.init() }
         return {
           responseResult: graphHelper.generateSuccess('LLM configuration updated successfully')
         }


### PR DESCRIPTION
## Summary
- add vector store field to LLM admin page and GraphQL API
- guard chat resolver by configured vector store
- introduce placeholder Neo4j memory module
- reload memory module when vector store changes to apply configuration without restart

## Testing
- `yarn test` *(fails: 'WIKI' is not defined in renderer.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c04c990918832badade2586c80378a